### PR TITLE
Keep commands with - unescaped

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function escapeCommand(command) {
     // Do not escape if this command is not dangerous..
     // We do this so that commands like "echo" or "ifconfig" work
     // Quoting them, will make them unnaccessible
-    return /^[a-z0-9_]+$/i.test(command) ? command : escapeArg(command, true);
+    return /^[a-z0-9_-]+$/i.test(command) ? command : escapeArg(command, true);
 }
 
 function spawn(command, args, options) {


### PR DESCRIPTION
Hi,

Here's a PR for this use case: https://github.com/typicode/minihost/issues/5
Not a Windows expert, so not sure why it tries to look in that particular PATH.

But basically, it seems like it doesn't like `-` in globally installed modules:

```javascript
var spawn = require('cross-spawn')
spawn('node-dev', [], { stdio: 'inherit' }) // KO
spawn('nodemon', [], { stdio: 'inherit' }) // OK
```

```
module.js:340
    throw err;
          ^
Error: Cannot find module 'D:\tmp\node-cross-spawn\node_modules\node-dev\bin\nod
e-dev'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
```

Tries to run `cmd.exe /s /c ""node-dev""` instead of `cmd.exe /s /c "node-dev"`

I've changed the `escapeCommand` so that it doesn't escape commands with `-`.
