### PR TITLE
Use `spawn-sync` for backwards compatibility with 0.10

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,7 @@ function spawnInternal(method, command, args, options) {
 
     args = args || [];
     options = options || {};
+    cp.spawnSync = require('spawn-sync');
 
     // Use node's spawn if not on windows
     if (!isWin) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "author": "IndigoUnited <hello@indigounited.com> (http://indigounited.com)",
   "license": "MIT",
   "dependencies": {
-    "lru-cache": "^2.5.0"
+    "lru-cache": "^2.5.0",
+    "spawn-sync": "^1.0.6"
   },
   "devDependencies": {
     "expect.js": "^0.3.0",

--- a/test/test.js
+++ b/test/test.js
@@ -1,16 +1,12 @@
 'use strict';
 
-var cp = require('child_process');
 var buffered = require('./util/buffered');
 var expect = require('expect.js');
 
 describe('cross-spawn', function () {
-    var methods = ['spawn'];
-
-    cp.spawnSync && methods.push('sync');
+    var methods = ['spawn', 'sync'];
 
     methods.forEach(function (method) {
-        if (cp.spawnSync)
         describe(method, function() {
             it('should support shebang in executables', function(next) {
                 buffered(method, __dirname + '/fixtures/shebang', function(err, data, code) {


### PR DESCRIPTION
This adds backwards compatibility with node 0.10.