### PR TITLE
Fixed a variable name collision that was causing failures on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var cp = require('child_process');
 var LRU = require('lru-cache');
-var spawnSync = require('spawn-sync');
+var sync = require('spawn-sync');
 
 var isWin = process.platform === 'win32';
 var shebangCache = LRU({ max: 50, maxAge: 30 * 1000 });
@@ -117,7 +117,7 @@ function spawn(command, args, options) {
 }
 
 function spawnSync(command, args, options) {
-    return spawnInternal(spawnSync, command, args, options);
+    return spawnInternal(sync, command, args, options);
 }
 
 module.exports = spawn;


### PR DESCRIPTION
This PR fixes https://github.com/IndigoUnited/node-cross-spawn/issues/14