### PR TITLE
Only spawn cmd.exe if necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ var child = spawn('npm', ['list', '-g', '-depth', '0'], { stdio: 'inherit' });
 var results = spawn.sync('npm', ['list', '-g', '-depth', '0'], { stdio: 'inherit' });
 ```
 
+## Caveat
+
+On Windows, cross-spawn will only spawn `cmd.exe` if necessary. If the extension
+of the executable is `.exe` or `.com`, it will spawn it directly. If you wish
+to override this behavior and *always* spawn a shell, pass the `{shell: true}`
+option.
+
 
 ## Tests
 

--- a/lib/hasBrokenSpawn.js
+++ b/lib/hasBrokenSpawn.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = (function () {
+    if (process.platform !== 'win32') {
+        return false;
+    }
+    var nodeVer = process.version.substr(1).split('.').map(function (num) {
+        return parseInt(num, 10);
+    });
+    return (nodeVer[0] === 0 && nodeVer[1] < 12);
+})();

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -74,11 +74,16 @@ function escapeCommand(command) {
     return /^[a-z0-9_-]+$/i.test(command) ? command : escapeArg(command, true);
 }
 
+function requiresShell(command) {
+    return !/\.(?:com|exe)$/i.test(command);
+}
+
 function parse(command, args, options) {
     var shebang;
     var applyQuotes;
     var file;
     var original;
+    var shell;
 
     // Normalize arguments, similar to nodejs
     if (args && !Array.isArray(args)) {
@@ -95,25 +100,31 @@ function parse(command, args, options) {
         file = resolveCommand(command);
         file = file || resolveCommand(command, true);
         shebang = file && readShebang(file);
+        shell = options.shell;
 
         if (shebang) {
             args.unshift(file);
             command = shebang;
+            shell = shell || requiresShell(resolveCommand(shebang) || resolveCommand(shebang, true));
+        } else {
+            shell = shell || requiresShell(file);
         }
 
-        // Escape command & arguments
-        applyQuotes = command !== 'echo';  // Do not quote arguments for the special "echo" command
-        command = escapeCommand(command);
-        args = args.map(function (arg) {
-            return escapeArg(arg, applyQuotes);
-        });
+        if (shell) {
+            // Escape command & arguments
+            applyQuotes = (command !== 'echo');  // Do not quote arguments for the special "echo" command
+            command = escapeCommand(command);
+            args = args.map(function (arg) {
+                return escapeArg(arg, applyQuotes);
+            });
 
-        // Use cmd.exe
-        args = ['/s', '/c', '"' + command + (args.length ? ' ' + args.join(' ') : '') + '"'];
-        command = process.env.comspec || 'cmd.exe';
+            // Use cmd.exe
+            args = ['/s', '/c', '"' + command + (args.length ? ' ' + args.join(' ') : '') + '"'];
+            command = process.env.comspec || 'cmd.exe';
 
-        // Tell node's spawn that the arguments are already escaped
-        options.windowsVerbatimArguments = true;
+            // Tell node's spawn that the arguments are already escaped
+            options.windowsVerbatimArguments = true;
+        }
     }
 
     return {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -3,6 +3,7 @@
 var fs = require('fs');
 var LRU = require('lru-cache');
 var resolveCommand = require('./resolveCommand');
+var hasBrokenSpawn = require('./hasBrokenSpawn');
 
 var isWin = process.platform === 'win32';
 var shebangCache = new LRU({ max: 50, maxAge: 30 * 1000 });  // Cache just for 30sec
@@ -100,7 +101,7 @@ function parse(command, args, options) {
         file = resolveCommand(command);
         file = file || resolveCommand(command, true);
         shebang = file && readShebang(file);
-        shell = options.shell;
+        shell = options.shell || hasBrokenSpawn;
 
         if (shebang) {
             args.unshift(file);

--- a/test/fixtures/win-ppid.js
+++ b/test/fixtures/win-ppid.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+var spawnSync = require('child_process').spawnSync;
+
+function ppidSync() {
+    var res = spawnSync('wmic',
+        ['process', 'where', '(processid=' + process.pid + ')', 'get', 'parentprocessid']);
+    var lines = res.stdout.toString().split(/\r?\n/);
+    return parseInt(lines[1].trim(), 10);
+}
+
+console.log(ppidSync());

--- a/test/fixtures/win-ppid.js
+++ b/test/fixtures/win-ppid.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var spawnSync = require('child_process').spawnSync;
+var spawnSync = require('child_process').spawnSync || require('spawn-sync');
 
 function ppidSync() {
     var res = spawnSync('wmic',

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,7 @@ var rimraf = require('rimraf');
 var mkdirp = require('mkdirp');
 var which = require('which');
 var buffered = require('./util/buffered');
+var hasBrokenSpawn = require('../lib/hasBrokenSpawn');
 var spawn = require('../');
 
 var isWin = process.platform === 'win32';
@@ -501,18 +502,27 @@ extension\');', { mode: parseInt('0777', 8) });
                 }
             });
 
-            it('should NOT spawn a shell for a .exe', function (next) {
-                if (!isWin) {
-                    next();
-                    return;
+            if (isWin) {
+                if (hasBrokenSpawn) {
+                    it('should spawn a shell for a .exe on old Node', function (next) {
+                        buffered(method, __dirname + '/fixtures/win-ppid.js', function (err, data, code) {
+                            expect(err).to.not.be.ok();
+                            expect(code).to.be(0);
+                            expect(data.trim()).to.not.equal('' + process.pid);
+                            next();
+                        });
+                    });
+                } else {
+                    it('should NOT spawn a shell for a .exe', function (next) {
+                        buffered(method, __dirname + '/fixtures/win-ppid.js', function (err, data, code) {
+                            expect(err).to.not.be.ok();
+                            expect(code).to.be(0);
+                            expect(data.trim()).to.equal('' + process.pid);
+                            next();
+                        });
+                    });
                 }
-                buffered(method, __dirname + '/fixtures/win-ppid.js', function (err, data, code) {
-                    expect(err).to.not.be.ok();
-                    expect(code).to.be(0);
-                    expect(data.trim()).to.equal('' + process.pid);
-                    next();
-                });
-            });
+            }
         });
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -500,6 +500,19 @@ extension\');', { mode: parseInt('0777', 8) });
                     next();
                 }
             });
+
+            it('should NOT spawn a shell for a .exe', function (next) {
+                if (!isWin) {
+                    next();
+                    return;
+                }
+                buffered(method, __dirname + '/fixtures/win-ppid.js', function (err, data, code) {
+                    expect(err).to.not.be.ok();
+                    expect(code).to.be(0);
+                    expect(data.trim()).to.equal('' + process.pid);
+                    next();
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
See #32.

I wasn't sure how to test whether cmd.exe got spawned. I ended up checking the parent process ID of the spawned process using WMI, as Node doesn't support it out of the box.