### PR TITLE
Node 6 shell option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ to override this behavior and *always* spawn a shell, pass the `{shell: true}`
 option, this option should be used carefully as no escaping will be performed and
 the spawn implementation provided by node will be used.
 
+While `{shell: false}` is supported, cross-spawn will throw an error when this option
+is used together with an executable without the `.exe` or `.com` extension.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ var results = spawn.sync('npm', ['list', '-g', '-depth', '0'], { stdio: 'inherit
 On Windows, cross-spawn will only spawn `cmd.exe` if necessary. If the extension
 of the executable is `.exe` or `.com`, it will spawn it directly. If you wish
 to override this behavior and *always* spawn a shell, pass the `{shell: true}`
-option.
+option, this option should be used carefully as no escaping will be performed and
+the spawn implementation provided by node will be used.
 
 
 ## Tests

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -96,7 +96,8 @@ function parse(command, args, options) {
     options = options || {};
     original = command;
 
-    if (isWin) {
+    // Certain commands require a shell under windows, auto-detect and properly escape those
+    if (isWin && !options.shell) {
         // Detect & add support for shebangs
         file = resolveCommand(command);
         file = file || resolveCommand(command, true);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -112,6 +112,10 @@ function parse(command, args, options) {
             shell = shell || requiresShell(file);
         }
 
+        if (options.shell === false && shell) {
+            throw new Error('Spawning ' + original + ' without shell is not supported.');
+        }
+
         if (shell) {
             // Escape command & arguments
             applyQuotes = (command !== 'echo');  // Do not quote arguments for the special "echo" command

--- a/test/test.js
+++ b/test/test.js
@@ -530,6 +530,13 @@ extension\');', { mode: parseInt('0777', 8) });
                             next();
                         });
                     });
+
+                    it('throws when trying to spawn without a shell for a .exe on old Node', function (next) {
+                        expect(function () {
+                            buffered(method, __dirname + '/fixtures/win-ppid.js', { shell: false }, function () {});
+                        }).to.throwException(/without shell is not supported/);
+                        next();
+                    });
                 } else {
                     it('should NOT spawn a shell for a .exe', function (next) {
                         buffered(method, __dirname + '/fixtures/win-ppid.js', function (err, data, code) {
@@ -539,7 +546,23 @@ extension\');', { mode: parseInt('0777', 8) });
                             next();
                         });
                     });
+
+                    it('allows to disable spawning with a shell for a .exe', function (next) {
+                        buffered(method, __dirname + '/fixtures/win-ppid.js', { shell: false }, function (err, data, code) {
+                            expect(err).to.not.be.ok();
+                            expect(code).to.be(0);
+                            expect(data.trim()).to.equal('' + process.pid);
+                            next();
+                        });
+                    });
                 }
+
+                it('throws when trying to spawn without a shell when a shell is required', function (next) {
+                    expect(function () {
+                        buffered(method, __dirname + '/fixtures/foo', { shell: false }, function () {});
+                    }).to.throwException(/without shell is not supported/);
+                    next();
+                });
             }
         });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -6,7 +6,9 @@ var expect = require('expect.js');
 var rimraf = require('rimraf');
 var mkdirp = require('mkdirp');
 var which = require('which');
+var os = require('os');
 var buffered = require('./util/buffered');
+var isNodeVersionLt = require('./util/is-node-version-lt');
 var hasBrokenSpawn = require('../lib/hasBrokenSpawn');
 var spawn = require('../');
 
@@ -325,6 +327,22 @@ extension\');', { mode: parseInt('0777', 8) });
 
                         next();
                     });
+                });
+            });
+
+            it('passes commands through when a shell is forced', function (next) {
+                if (isNodeVersionLt(6)) { // Node < 6 has no shell option
+                    return this.skip();
+                }
+
+                buffered(method, 'echo', [
+                    'hello',
+                ], { shell: true }, function (err, data, code) {
+                    expect(err).to.not.be.ok();
+                    expect(code).to.be(0);
+                    expect(data).to.equal('hello' + os.EOL);
+
+                    next();
                 });
             });
 

--- a/test/util/is-node-version-lt.js
+++ b/test/util/is-node-version-lt.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = function isNodeVersionLt(version) {
+    var nodeVer = process.version.substr(1).split('.').map(function (num) {
+        return parseInt(num, 10);
+    });
+    return (nodeVer[0] < version);
+};


### PR DESCRIPTION
When using spawn and the shell option provided by Node >=6,
the command has already been escaped for none windows platforms.

Remove all double quotes and re-escape it for windows.

Fixes https://github.com/IndigoUnited/node-cross-spawn/issues/42