### PR TITLE
Fixes bug: unable to spawn .bat with %<environment variable>% in name

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -51,7 +51,13 @@ function parseNonShell(parsed) {
         });
 
         // Make use of cmd.exe
-        // Pass command as environment variable
+        // Anything passed to cmd.exe after the `/c` argument is subject to environment variable expansion.
+        // This means, for example, that if we intend to execute a file named "%cd%.bat" we need to ensure cmd.exe
+        // doesn't replace "%cd%" with the value of the "cd" environment variable. (See tests for an example)
+        // The only way to do this is to pass our entire command string as an environment variable and tell
+        // cmd to execute it as a command.  (environment variable expansion is not recursive)
+        // We must also delete our custom environment variable first to prevent it from leaking into the environment
+        // of the command we're executing.
         parsed.options.env = assign({}, parsed.options.env || process.env);
         do {
             envVariableName = 'cross_spawn_command_' + envVariableSuffix;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -17,6 +17,10 @@ function parseNonShell(parsed) {
     var shebang;
     var needsShell;
     var applyQuotes;
+    var command;
+    var args;
+    var envVariableName;
+    var envVariableSuffix = 1;
 
     if (!isWin) {
         return parsed;
@@ -39,13 +43,20 @@ function parseNonShell(parsed) {
     if (needsShell) {
         // Escape command & arguments
         applyQuotes = (parsed.command !== 'echo');  // Do not quote arguments for the special "echo" command
-        parsed.command = escapeCommand(parsed.command);
-        parsed.args = parsed.args.map(function (arg) {
+        command = escapeCommand(parsed.command);
+        args = parsed.args.map(function (arg) {
             return escapeArgument(arg, applyQuotes);
         });
 
         // Make use of cmd.exe
-        parsed.args = ['/d', '/s', '/c', '"' + parsed.command + (parsed.args.length ? ' ' + parsed.args.join(' ') : '') + '"'];
+        // Pass command as environment variable
+        parsed.options.env = assign({}, parsed.options.env || process.env);
+        do {
+            envVariableName = 'cross_spawn_command_' + envVariableSuffix;
+            envVariableSuffix += 1;
+        } while (Object.prototype.hasOwnProperty.call(parsed.options.env, envVariableName));
+        parsed.options.env[envVariableName] = command + (args.length ? ' ' + args.join(' ') : '');
+        parsed.args = ['/d', '/s', '/c', '"set ' + envVariableName + '=& %' + envVariableName + '%"'];
         parsed.command = process.env.comspec || 'cmd.exe';
         parsed.options.windowsVerbatimArguments = true;  // Tell node's spawn that the arguments are already escaped
     }
@@ -108,6 +119,18 @@ function parse(command, args, options) {
 
     // Delegate further parsing to shell or non-shell
     return options.shell ? parseShell(parsed) : parseNonShell(parsed);
+}
+
+// Like Object.assign, for older node versions
+function assign(target, source) {
+    var key;
+
+    for (key in source) {
+        if (Object.prototype.hasOwnProperty.call(source, key)) {
+            target[key] = source[key];
+        }
+    }
+    return target;
 }
 
 module.exports = parse;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var assign = require('lodash.assign');
+
 var resolveCommand = require('./util/resolveCommand');
 var hasEmptyArgumentBug = require('./util/hasEmptyArgumentBug');
 var escapeArgument = require('./util/escapeArgument');
@@ -119,18 +121,6 @@ function parse(command, args, options) {
 
     // Delegate further parsing to shell or non-shell
     return options.shell ? parseShell(parsed) : parseNonShell(parsed);
-}
-
-// Like Object.assign, for older node versions
-function assign(target, source) {
-    var key;
-
-    for (key in source) {
-        if (Object.prototype.hasOwnProperty.call(source, key)) {
-            target[key] = source[key];
-        }
-    }
-    return target;
 }
 
 module.exports = parse;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -116,7 +116,7 @@ function parse(command, args, options) {
     }
 
     args = args ? args.slice(0) : [];  // Clone array to avoid changing the original
-    options = options || {};
+    options = options ? assign({}, options) : {}; // Clone object to avoid changing the original
 
     // Build our parsed object
     parsed = {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -58,6 +58,8 @@ function parseNonShell(parsed) {
         // cmd to execute it as a command.  (environment variable expansion is not recursive)
         // We must also delete our custom environment variable first to prevent it from leaking into the environment
         // of the command we're executing.
+
+        // Must copy `env` to avoid mutating the original
         parsed.options.env = assign({}, parsed.options.env || process.env);
         do {
             envVariableName = 'cross_spawn_command_' + envVariableSuffix;

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "author": "IndigoUnited <hello@indigounited.com> (http://indigounited.com)",
   "license": "MIT",
   "dependencies": {
+    "lodash.assign": "^4.2.0",
     "lru-cache": "^4.0.1",
     "shebang-command": "^1.2.0",
     "which": "^1.2.9"

--- a/test/fixtures/%CD%
+++ b/test/fixtures/%CD%
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo special

--- a/test/fixtures/%CD%.bat
+++ b/test/fixtures/%CD%.bat
@@ -1,0 +1,2 @@
+@echo off
+echo special

--- a/test/fixtures/echoEnv
+++ b/test/fixtures/echoEnv
@@ -1,0 +1,1 @@
+echo "$FOO""$BAR"

--- a/test/fixtures/echoEnv.bat
+++ b/test/fixtures/echoEnv.bat
@@ -1,0 +1,2 @@
+@echo off
+echo %FOO%%BAR%

--- a/test/test.js
+++ b/test/test.js
@@ -140,6 +140,16 @@ extension\');', { mode: parseInt('0777', 8) });
                 });
             });
 
+            it('should handle commands with names of environment variables', function (next) {
+                buffered(method, __dirname + '/fixtures/%CD%', function (err, data, code) {
+                    expect(err).to.not.be.ok();
+                    expect(code).to.be(0);
+                    expect(data.trim()).to.equal('special');
+
+                    next();
+                });
+            });
+
             it('should handle arguments with quotes', function (next) {
                 buffered(method, 'node', [
                     __dirname + '/fixtures/echo',

--- a/test/test.js
+++ b/test/test.js
@@ -150,6 +150,40 @@ extension\');', { mode: parseInt('0777', 8) });
                 });
             });
 
+            describe('should preserve environment variables', function () {
+                before(function () {
+                    process.env.FOO = 'foovalue';
+                });
+
+                it('when env dictionary is omitted', function (next) {
+                    buffered(method, __dirname + '/fixtures/echoEnv', function (err, data, code) {
+                        expect(err).to.not.be.ok();
+                        expect(code).to.be(0);
+                        expect(data.trim()).to.equal('foovalue');
+
+                        next();
+                    });
+                });
+
+                it('when env dictionary is passed', function (next) {
+                    buffered(method, __dirname + '/fixtures/echoEnv', {
+                        env: {
+                            BAR: 'barvalue',
+                        },
+                    }, function (err, data, code) {
+                        expect(err).to.not.be.ok();
+                        expect(code).to.be(0);
+                        expect(data.trim()).to.equal('barvalue');
+
+                        next();
+                    });
+                });
+
+                after(function () {
+                    delete process.env.FOO;
+                });
+            });
+
             it('should handle arguments with quotes', function (next) {
                 buffered(method, 'node', [
                     __dirname + '/fixtures/echo',

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@ var path = require('path');
 var expect = require('expect.js');
 var rimraf = require('rimraf');
 var mkdirp = require('mkdirp');
+var assign = require('lodash.assign');
 var hasEmptyArgumentBug = require('../lib/util/hasEmptyArgumentBug');
 var spawn = require('../');
 var buffered = require('./util/buffered');
@@ -568,6 +569,25 @@ extension\');', { mode: parseInt('0777', 8) });
                     });
                 }
             }
+
+            it('should not mutate passed `options` or `env` objects', function (next) {
+                var options = {
+                    env: {
+                        a: 'a',
+                        b: 'b',
+                    },
+                };
+                var env = options.env;
+                var optionsClone = assign({}, options);
+                var envClone = assign({}, env);
+
+                buffered(method, __dirname + '/fixtures/foo', options, function (err) {
+                    expect(err).to.not.be.ok();
+                    expect(options).to.eql(optionsClone);
+                    expect(env).to.eql(envClone);
+                    next();
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
Spawning `cmd /D /S /C <command string>` is susceptible to environment variable expansion.  I've added a failing test that illustrates the problem.

The only solution I've devised is to pass the command to be executed as an environment variable, *not* after the `/c` flag.  Here's an example:

```
child_process.spawnSync('cmd', [
  '/d /s /c set secret_env_variable_with_cmd_string=& %secret_env_variable_with_cmd_string%'
], {
  stdio: 'inherit',
  windowsVerbatimArguments: true,
  env: {
    secret_env_variable_with_cmd_string: "%CD%.bat firstArgument secondArgument"
  }
});
```