### PR TITLE
English Wikipedia reference in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you are using `spawnSync` on node 0.10 or older, you will also need to instal
 Node has issues when using spawn on Windows:
 
 - It ignores [PATHEXT](https://github.com/joyent/node/issues/2318)
-- It does not support [shebangs](http://pt.wikipedia.org/wiki/Shebang)
+- It does not support [shebangs](https://en.wikipedia.org/wiki/Shebang_(Unix))
 - No `options.shell` support on node `<v4.8`
 - It does not allow you to run `del` or `dir`
 


### PR DESCRIPTION
Changed the shebang Wikipedia link to the Wikipedia article in English, because the documentation is English and should be consistent.